### PR TITLE
Turn titan into read-only on error during gc and version_change (#42)

### DIFF
--- a/src/db_impl_gc.cc
+++ b/src/db_impl_gc.cc
@@ -65,7 +65,6 @@ Status TitanDBImpl::BackgroundGC(LogBuffer* log_buffer) {
   std::unique_ptr<BlobGC> blob_gc;
   std::unique_ptr<ColumnFamilyHandle> cfh;
   Status s;
-
   if (!gc_queue_.empty()) {
     uint32_t column_family_id = PopFirstFromGCQueue();
     auto bs = vset_->GetBlobStorage(column_family_id).lock().get();
@@ -108,6 +107,7 @@ Status TitanDBImpl::BackgroundGC(LogBuffer* log_buffer) {
   if (s.ok()) {
     // Done
   } else {
+    SetBGError(s);
     ROCKS_LOG_WARN(db_options_.info_log, "Titan GC error: %s",
                    s.ToString().c_str());
   }

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -225,6 +225,30 @@ class TitanDBTest : public testing::Test {
     DeleteDir(env_, dbname_);
   }
 
+  void SetBGError(const Status& s) {
+    MutexLock l(&db_impl_->mutex_);
+    db_impl_->SetBGError(s);
+  }
+
+  void CallGC() {
+    db_impl_->bg_gc_scheduled_++;
+    db_impl_->BackgroundCallGC();
+    while (db_impl_->bg_gc_scheduled_)
+      ;
+  }
+
+  // Make db ignore first bg_error
+  class BGErrorListener : public EventListener {
+   public:
+    void OnBackgroundError(BackgroundErrorReason reason,
+                           Status* error) override {
+      if (++cnt == 1) *error = Status();
+    }
+
+   private:
+    int cnt{0};
+  };
+
   Env* env_{Env::Default()};
   std::string dbname_;
   TitanOptions options_;
@@ -746,6 +770,49 @@ TEST_F(TitanDBTest, FallbackModeEncounterMissingBlobFile) {
   Slice end("foo1");
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), &begin, &end));
   VerifyDB({{"bar", "v1"}});
+}
+
+TEST_F(TitanDBTest, BackgroundErrorHandling) {
+  options_.listeners.emplace_back(std::make_shared<BGErrorListener>());
+  Open();
+  std::string key = "key", val = "val";
+  SetBGError(Status::IOError(""));
+  // BG error is restored by listener for first time
+  ASSERT_OK(db_->Put(WriteOptions(), key, val));
+  SetBGError(Status::IOError(""));
+  ASSERT_OK(db_->Get(ReadOptions(), key, &val));
+  ASSERT_EQ(val, "val");
+  ASSERT_TRUE(db_->Put(WriteOptions(), key, val).IsIOError());
+  ASSERT_TRUE(db_->Flush(FlushOptions()).IsIOError());
+  ASSERT_TRUE(db_->Delete(WriteOptions(), key).IsIOError());
+  ASSERT_TRUE(
+      db_->CompactRange(CompactRangeOptions(), nullptr, nullptr).IsIOError());
+  ASSERT_TRUE(
+      db_->CompactFiles(CompactionOptions(), std::vector<std::string>(), 1)
+          .IsIOError());
+  Close();
+}
+TEST_F(TitanDBTest, BackgroundErrorTrigger) {
+  std::unique_ptr<TitanFaultInjectionTestEnv> mock_env(
+      new TitanFaultInjectionTestEnv(env_));
+  options_.env = mock_env.get();
+  Open();
+  std::map<std::string, std::string> data;
+  const int kNumEntries = 100;
+  for (uint64_t i = 1; i <= kNumEntries; i++) {
+    Put(i, &data);
+  }
+  Flush();
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+  SyncPoint::GetInstance()->SetCallBack("VersionSet::LogAndApply", [&](void*) {
+    mock_env->SetFilesystemActive(false, Status::IOError("Injected error"));
+  });
+  SyncPoint::GetInstance()->EnableProcessing();
+  CallGC();
+  mock_env->SetFilesystemActive(true);
+  // Still failed for bg error
+  ASSERT_TRUE(db_impl_->Put(WriteOptions(), "key", "val").IsIOError());
+  Close();
 }
 
 }  // namespace titandb


### PR DESCRIPTION
- Set background error if encountered a critical error. Now it's set for two cases
    - BackgroundGC() error
    - LogAndApply() error after generate new blob file
- If background error is set, all following foreground write operations will be refused and return background error status